### PR TITLE
feat: bumping POM to version `1.0.0-rc1`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>com.github.kafkesc</groupId>
   <artifactId>skemium</artifactId>
-  <version>0.0.2-dev</version>
+  <version>1.0.0-rc1</version>
 
   <name>skemium</name>
   <url>https://github.com/kafkesc/skemium</url>


### PR DESCRIPTION
### What this does

Bumps version in `pom.xml` to first release candidate: `1.0.0-rc1`

### Notes for the reviewer

This is what I aim to use for `registry` (see https://snyksec.atlassian.net/browse/DP-3165).

