### PR TITLE
fix: compile GraalVM binary with `-march=compatibility`

### DIFF
--- a/.github/workflows/release-binaries.yaml
+++ b/.github/workflows/release-binaries.yaml
@@ -38,6 +38,8 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           cache: maven
           native-image-job-reports: true
+      - name: GraalVM supported '-march' options
+        run: native-image -march=list
       - name: Package Binary
         run: mvn -B package native:compile-no-fork -DskipTests
       - name: Capture artifact metadata

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>com.github.kafkesc</groupId>
   <artifactId>skemium</artifactId>
-  <version>1.0.0-rc2</version>
+  <version>1.0.0-rc3</version>
 
   <name>skemium</name>
   <url>https://github.com/kafkesc/skemium</url>

--- a/pom.xml
+++ b/pom.xml
@@ -347,7 +347,7 @@
             <!-- See: https://docs.oracle.com/en/graalvm/jdk/21/docs/reference-manual/native-image/overview/Options/#build-options -->
             <buildArgs>
               <buildArg>-O3</buildArg>
-              <buildArg>-march=native</buildArg>
+              <buildArg>-march=compatibility</buildArg>
               <buildArg>-H:+UnlockExperimentalVMOptions</buildArg>
               <buildArg>-H:IncludeResources=logback.xml|META-INF/MANIFEST.MF</buildArg>
             </buildArgs>


### PR DESCRIPTION
JIRA: https://snyksec.atlassian.net/browse/DP-3350

Execution was failing on CircleCI with error:

```
The current machine does not support all of the following CPU features that are required by the image: [CX8, CMOV, FXSR, HT, MMX, AMD_3DNOW_PREFETCH, SSE, SSE2, SSE3, SSSE3, SSE4A, SSE4_1, SSE4_2, POPCNT, LZCNT, TSC, TSCINV_BIT, AVX, AVX2, AES, ERMS, CLMUL, BMI1, BMI2, ADX, SHA, FMA, VZEROUPPER, FLUSH, FLUSHOPT, HV, RDTSCP, RDPID, FSRM, F16C, CET_SS].
Please rebuild the executable with an appropriate setting of the -march option.
Exited with code exit status 1
```

This turned out to be because `-march=native` hyper-optimises the binary, by enabling ALL the feature of the specific hardware generating the binary (in our case, GitHub own workers, that seem to be very recent AMD CPUs).

