### PR TITLE
fix: provide GraalVM with "reachability metadata hints" [DP-3351]

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>com.github.kafkesc</groupId>
   <artifactId>skemium</artifactId>
-  <version>1.0.0-rc3</version>
+  <version>1.0.0-rc4</version>
 
   <name>skemium</name>
   <url>https://github.com/kafkesc/skemium</url>

--- a/pom.xml
+++ b/pom.xml
@@ -348,8 +348,6 @@
             <buildArgs>
               <buildArg>-O3</buildArg>
               <buildArg>-march=compatibility</buildArg>
-              <buildArg>-H:+UnlockExperimentalVMOptions</buildArg>
-              <buildArg>-H:IncludeResources=logback.xml|META-INF/MANIFEST.MF</buildArg>
             </buildArgs>
             <mainClass>${const.mainClass}</mainClass>
           </configuration>

--- a/src/main/java/io/snyk/skemium/helpers/JSON.java
+++ b/src/main/java/io/snyk/skemium/helpers/JSON.java
@@ -1,8 +1,10 @@
 package io.snyk.skemium.helpers;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.StreamReadFeature;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.json.JsonMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 
 import java.io.File;
@@ -10,8 +12,10 @@ import java.io.IOException;
 
 /// Helper to interact with JSON.
 public class JSON {
-    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper()
-            .registerModule(new JavaTimeModule());
+    private static final ObjectMapper OBJECT_MAPPER = JsonMapper.builder()
+            .enable(StreamReadFeature.INCLUDE_SOURCE_IN_LOCATION)
+            .addModule(new JavaTimeModule())
+            .build();
 
     public static String pretty(final String jsonStr) throws JsonProcessingException {
         return pretty(toJsonNode(jsonStr));

--- a/src/main/resources/META-INF/native-image/README.md
+++ b/src/main/resources/META-INF/native-image/README.md
@@ -1,0 +1,63 @@
+# GraalVM `native-image` Reachability Metadata
+
+When compiling a native binary out of a Java project using `native-image`, [GraalVM] tries really hard
+to omit from the final binary any unused class: it does it for performance and final binary size reasons.
+Through static code analysis, it compiles a _graph_ of what code is _actually_ used by the binary.
+
+The only issue with this static code analysis, is that it is done at build time, so it misses classes
+that are dynamically loaded at runtime via `java.lang.Class.forName()`. Detailed documentation
+can be found [here][Reachability Metadata].
+
+Because of this we need to provide "hints" for the `native-image` compiler to spot classes and resources
+that it wouldn't normally include.
+
+So we provide under the path `src/main/resources/META-INF/native-image` 2 JSON files:
+
+* `reflect-config.json`: Classes we want included and are not picked up automatically
+* `resource-config.json`: Resources expected by libraries to live at `src/main/resources`
+
+## How do we know what classes were picked up and which weren't?
+
+This is tricky: we need to test the binary, and determine what wasn't picked up by looking at the exceptions
+the executable will throw. For example
+
+```shell
+10:05:38.142 [main] ERROR io.snyk.skemium.GenerateCommand -- Failed to generate Database Tables Schemas
+java.lang.IllegalArgumentException: Unable to find class io.debezium.connector.postgresql.PostgresSourceInfoStructMaker
+	at io.debezium.config.Instantiator.getInstanceWithProvidedConstructorType(Instantiator.java:68)
+	at io.debezium.config.Instantiator.getInstance(Instantiator.java:33)
+	at io.debezium.config.Configuration.getInstance(Configuration.java:1528)
+	at io.debezium.config.CommonConnectorConfig.getSourceInfoStructMaker(CommonConnectorConfig.java:1697)
+	at io.debezium.connector.postgresql.PostgresConnectorConfig.getSourceInfoStructMaker(PostgresConnectorConfig.java:1252)
+	at io.debezium.config.CommonConnectorConfig.<init>(CommonConnectorConfig.java:1202)
+	at io.debezium.relational.RelationalDatabaseConnectorConfig.<init>(RelationalDatabaseConnectorConfig.java:588)
+	at io.debezium.connector.postgresql.PostgresConnectorConfig.<init>(PostgresConnectorConfig.java:1097)
+	at io.snyk.skemium.db.postgres.PostgresTableSchemaFetcher.<init>(PostgresTableSchemaFetcher.java:50)
+	at io.snyk.skemium.db.DatabaseKind.fetcher(DatabaseKind.java:24)
+	at io.snyk.skemium.GenerateCommand.call(GenerateCommand.java:136)
+	at io.snyk.skemium.GenerateCommand.call(GenerateCommand.java:29)
+	at picocli.CommandLine.executeUserObject(CommandLine.java:2031)
+	at picocli.CommandLine.access$1500(CommandLine.java:148)
+	at picocli.CommandLine$RunLast.executeUserObjectOfLastSubcommandWithSameParent(CommandLine.java:2469)
+	at picocli.CommandLine$RunLast.handle(CommandLine.java:2461)
+	at picocli.CommandLine$RunLast.handle(CommandLine.java:2423)
+	at picocli.CommandLine$AbstractParseResultHandler.execute(CommandLine.java:2277)
+	at picocli.CommandLine$RunLast.execute(CommandLine.java:2425)
+	at picocli.CommandLine.execute(CommandLine.java:2174)
+	at io.snyk.skemium.SkemiumMain.main(SkemiumMain.java:41)
+	at java.base@21.0.7/java.lang.invoke.LambdaForm$DMH/sa346b79c.invokeStaticInit(LambdaForm$DMH)
+Caused by: java.lang.ClassNotFoundException: io.debezium.connector.postgresql.PostgresSourceInfoStructMaker
+	at java.base@21.0.7/jdk.internal.loader.BuiltinClassLoader.loadClass(BuiltinClassLoader.java:52)
+	at java.base@21.0.7/jdk.internal.loader.ClassLoaders$AppClassLoader.loadClass(ClassLoaders.java:188)
+	at java.base@21.0.7/java.lang.ClassLoader.loadClass(ClassLoader.java:121)
+	at io.debezium.config.Instantiator.getInstanceWithProvidedConstructorType(Instantiator.java:63)
+	... 21 common frames omitted
+```
+
+Indicates that `io.debezium.connector.postgresql.PostgresSourceInfoStructMaker` was not included by `native-image`
+during the static analysis it did. And so, we need to explicitly include it.
+
+For details, please refer to the [Reachability Metadata] documentation provided by [GraalVM] 
+
+[Reachability Metadata]: https://www.graalvm.org/latest/reference-manual/native-image/metadata/
+[GraalVM]: https://www.graalvm.org/

--- a/src/main/resources/META-INF/native-image/reflect-config.json
+++ b/src/main/resources/META-INF/native-image/reflect-config.json
@@ -1,0 +1,38 @@
+[
+  {
+    "name" : "io.debezium.connector.postgresql.PostgresSourceInfoStructMaker",
+    "allDeclaredConstructors" : true,
+    "allPublicConstructors" : true,
+    "allDeclaredMethods" : true,
+    "allPublicMethods" : true,
+    "allDeclaredFields" : true,
+    "allPublicFields" : true
+  },
+  {
+    "name": "io.debezium.pipeline.txmetadata.DefaultTransactionMetadataFactory",
+    "allDeclaredConstructors" : true,
+    "allPublicConstructors" : true,
+    "allDeclaredMethods" : true,
+    "allPublicMethods" : true,
+    "allDeclaredFields" : true,
+    "allPublicFields" : true
+  },
+  {
+    "name": "org.eclipse.jgit.lib.CoreConfig$TrustStat",
+    "allDeclaredConstructors" : true,
+    "allPublicConstructors" : true,
+    "allDeclaredMethods" : true,
+    "allPublicMethods" : true,
+    "allDeclaredFields" : true,
+    "allPublicFields" : true
+  },
+  {
+    "name" : "io.snyk.skemium.meta.MetadataFile",
+    "allDeclaredConstructors" : true,
+    "allPublicConstructors" : true,
+    "allDeclaredMethods" : true,
+    "allPublicMethods" : true,
+    "allDeclaredFields" : true,
+    "allPublicFields" : true
+  }
+]

--- a/src/main/resources/META-INF/native-image/resource-config.json
+++ b/src/main/resources/META-INF/native-image/resource-config.json
@@ -1,0 +1,13 @@
+{
+  "globs": [
+    {
+      "glob": "io/debezium/connector/postgresql/build.version"
+    },
+    {
+      "glob": "META-INF/MANIFEST.MF"
+    },
+    {
+      "glob": "logback.xml"
+    }
+  ]
+}


### PR DESCRIPTION
### What this does

Addresses issue with GraalVM not including dynamically-loaded classes, as they were not detected during the initial static code analysis.

Closes #20 

### Notes for the reviewer

Please refer to the additional `README.md` provided in this PR.

### Missed anything?

- [ ] Tests written (if applicable) [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [x] Documentation written (if applicable) [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### More information?

- JIRA: https://snyksec.atlassian.net/browse/DP-3351