### PR TITLE
feat: preparing `v1.4.0`, that include Debezium `3.4.x` [DP-3870]

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -230,8 +230,8 @@ All dependency versions are centralized in `pom.xml` `<properties>` using the `v
 
 ```xml
 <ver.avro>1.12.1</ver.avro>
-<ver.jackson>2.21.1</ver.jackson>
-<ver.debezium>3.0.8.Final</ver.debezium>
+<ver.jackson>2.21.3</ver.jackson>
+<ver.debezium>3.4.3.Final</ver.debezium>
 ```
 
 Dependabot is configured (`.github/dependabot.yml`) for automated dependency updates. Configuration:
@@ -327,7 +327,7 @@ git push origin main --follow-tags --tags      # Push tag triggers release workf
 
 10. **Environment variable fallback**: All CLI options support environment variable configuration via Picocli's `${env:VAR_NAME}` defaultValue syntax (e.g., `DB_HOSTNAME`, `DB_PORT`, `COMPATIBILITY`, `CI_MODE`).
 
-11. **`PostgresSchemaRefreshable` is intentionally package-local**: It extends `PostgresSchema` to expose the `refresh()` method which is hidden inside the Debezium Postgres Connector library. This is necessary to load table schemas. Don't make it public.
+11. **`PostgresSchemaRefreshable` is intentionally package-local**: It extends `PostgresSchema` to expose the `refresh()` method which is hidden inside the Debezium Postgres Connector library. This is necessary to load table schemas. Don't make it public. Its constructor must mirror the upstream `PostgresSchema` constructor, which **changed in Debezium 3.4** to take a `CdcSourceTaskContext<PostgresConnectorConfig>` (instead of a bare `PostgresConnectorConfig`) plus a `CustomConverterRegistry`. `PostgresTableSchemaFetcher` constructs both inline (`new CdcSourceTaskContext<>(rawConfig, connectorConfig, connectorConfig.getCustomMetricTags())` and `new CustomConverterRegistry(null)` — `null` yields an empty converter list). Future Debezium upgrades may change this signature again; check `io.debezium.connector.postgresql.PostgresSchema` and `PostgresConnectorTask#start()` in the Debezium sources for the canonical construction pattern.
 
 12. **Topic naming strategy**: `CatalogSchemaAndTableTopicNamingStrategy` formats topics as `<catalog>.<schema>.<table>` (e.g., `chinook.public.artist`). This naming is also used as the table identifier (`TableAvroSchemas.identifier()`).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.4.0] - 2026-05-14
+
+> [!NOTE]
+> In an excess of caution, we are bumping the minor version of Skemium to match the bumping in minor version of Debezium.
+> As Debezium is a _core_ dependency here, we prefer to signal this change more clearly than with a patch version bump.
+> BUT, in our testing though, not breaking change has surfaced in Skemium.
+
+### Changed
+
+- Bumped Debezium from `3.2.7.Final` to `3.4.3.Final`.
+- Bumped grouped Java dependencies: JUnit BOM `5.14.3` → `5.14.4`, `lz4-java` `1.10.4` → `1.11.0`, `slf4j-api` `2.0.17` → `2.0.18`, `commons-codec` `1.21.0` → `1.22.0`, and Jackson modules (`jackson-core`, `jackson-databind`, `jackson-datatype-jsr310`, `jackson-dataformat-avro`) `2.21.2` → `2.21.3`.
+- Bumped GitHub Actions `softprops/action-gh-release` from `2` to `3` in the release workflows.
+- Updated `CODEOWNERS` (PRODSEC-10215).
+
+### Fixed
+
+- Upgraded `org.postgresql:postgresql` to `42.7.11` to address security vulnerabilities.
+
 ## [1.3.0] - 2026-04-02
 
 ### Added

--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
     <ver.commons-codec>1.22.0</ver.commons-codec>
     <ver.commons-compress>1.28.0</ver.commons-compress>
     <ver.commons-lang3>3.20.0</ver.commons-lang3>
-    <ver.debezium>3.2.7.Final</ver.debezium>
+    <ver.debezium>3.4.3.Final</ver.debezium>
     <!--
       All versions of Jackson libraries have the same versioning, but for some reason `jackson-annotations@X.Y`
       doesn't use the patch version.

--- a/src/main/java/io/snyk/skemium/db/postgres/PostgresSchemaRefreshable.java
+++ b/src/main/java/io/snyk/skemium/db/postgres/PostgresSchemaRefreshable.java
@@ -1,10 +1,12 @@
 package io.snyk.skemium.db.postgres;
 
+import io.debezium.connector.common.CdcSourceTaskContext;
 import io.debezium.connector.postgresql.PostgresConnectorConfig;
 import io.debezium.connector.postgresql.PostgresSchema;
 import io.debezium.connector.postgresql.PostgresValueConverter;
 import io.debezium.connector.postgresql.connection.PostgresConnection;
 import io.debezium.connector.postgresql.connection.PostgresDefaultValueConverter;
+import io.debezium.relational.CustomConverterRegistry;
 import io.debezium.relational.TableId;
 import io.debezium.spi.topic.TopicNamingStrategy;
 
@@ -16,8 +18,12 @@ import java.sql.SQLException;
  * but here we need it to load tables' schemas.
  */
 class PostgresSchemaRefreshable extends PostgresSchema {
-    PostgresSchemaRefreshable(PostgresConnectorConfig config, PostgresDefaultValueConverter defaultValueConverter, TopicNamingStrategy<TableId> topicNamingStrategy, PostgresValueConverter valueConverter) {
-        super(config, defaultValueConverter, topicNamingStrategy, valueConverter);
+    PostgresSchemaRefreshable(CdcSourceTaskContext<PostgresConnectorConfig> taskContext,
+                              PostgresDefaultValueConverter defaultValueConverter,
+                              TopicNamingStrategy<TableId> topicNamingStrategy,
+                              PostgresValueConverter valueConverter,
+                              CustomConverterRegistry customConverterRegistry) {
+        super(taskContext, defaultValueConverter, topicNamingStrategy, valueConverter, customConverterRegistry);
     }
 
     @Override

--- a/src/main/java/io/snyk/skemium/db/postgres/PostgresTableSchemaFetcher.java
+++ b/src/main/java/io/snyk/skemium/db/postgres/PostgresTableSchemaFetcher.java
@@ -1,11 +1,13 @@
 package io.snyk.skemium.db.postgres;
 
 import io.debezium.config.Configuration;
+import io.debezium.connector.common.CdcSourceTaskContext;
 import io.debezium.connector.postgresql.PostgresConnectorConfig;
 import io.debezium.connector.postgresql.PostgresValueConverter;
 import io.debezium.connector.postgresql.TypeRegistry;
 import io.debezium.connector.postgresql.connection.PostgresConnection;
 import io.debezium.connector.postgresql.connection.PostgresDefaultValueConverter;
+import io.debezium.relational.CustomConverterRegistry;
 import io.debezium.relational.TableId;
 import io.debezium.relational.TableSchema;
 import io.debezium.relational.Tables;
@@ -137,10 +139,11 @@ public class PostgresTableSchemaFetcher implements TableSchemaFetcher {
                 : new PostgresConnectorConfig(configuration);
 
         try (final PostgresSchemaRefreshable postgresSchema = new PostgresSchemaRefreshable(
-                connectorConfig,
+                new CdcSourceTaskContext<>(configuration, connectorConfig, connectorConfig.getCustomMetricTags()),
                 defaultValueConverter,
                 CatalogSchemaAndTableTopicNamingStrategy.create(connectorConfig),
-                valueConverter)) {
+                valueConverter,
+                new CustomConverterRegistry(null))) {
             postgresSchema.refresh(connection, true);
 
             for (final TableId tId : allSelectedTables) {


### PR DESCRIPTION
### What this does

Bumping version of Debezium to `3.4.x` and preparing to release a new version of Skemium.

### Notes for the reviewer

Small change in interface from one of the classes we use from Debezium: behaviour unchanged.

### Missed anything?

- [ ] Tests written (if applicable) [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [x] Documentation written (if applicable) [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### More information?

- Issue: https://snyksec.atlassian.net/browse/DP-3870
- Documentation: N/A
- Closes #86
- Closes #87

### Screenshots?

_Visuals that may help the reviewer_
