### PR TITLE
fix: register openlineage build.version as native image resource

### DIFF
--- a/src/main/resources/META-INF/native-image/resource-config.json
+++ b/src/main/resources/META-INF/native-image/resource-config.json
@@ -4,6 +4,9 @@
       "glob": "io/debezium/connector/postgresql/build.version"
     },
     {
+      "glob": "io/debezium/openlineage/build.version"
+    },
+    {
       "glob": "META-INF/MANIFEST.MF"
     },
     {


### PR DESCRIPTION
### What this does

Debezium 3.2.x (introduced in skemium 1.3.0) added an OpenLineage integration module. Its `Module` class has a static initializer that loads a version properties file at class-load time:

```java
// io.debezium.openlineage.Module
private static final Properties INFO = IoUtil.loadProperties(Module.class, "io/debezium/openlineage/build.version");
```

In a GraalVM native image, classpath resources are stripped unless explicitly registered in `resource-config.json`. Without this entry, `getResourceAsStream()` returns `null`, `Properties.load(null)` hits `Objects.requireNonNull()`, and the binary crashes with `ExceptionInInitializerError` immediately on `skemium generate`:

```
Exception in thread "main" java.lang.ExceptionInInitializerError
    at io.debezium.openlineage.ConnectorContext.from(ConnectorContext.java:63)
    at io.debezium.openlineage.DebeziumOpenLineageEmitter.connectorContext(...)
    at io.debezium.relational.RelationalDatabaseSchema.buildAndRegisterSchema(...)
    ...
Caused by: java.lang.NullPointerException
    at java.util.Objects.requireNonNull(Objects.java:259)
    at java.util.Properties.load(Properties.java:408)
    at io.debezium.util.IoUtil.loadProperties(IoUtil.java:496)
    at io.debezium.openlineage.Module.<clinit>(Module.java:13)
```

This fix adds the missing glob, following the identical pattern already in place for `io/debezium/connector/postgresql/build.version`.

The regression affects both 1.3.0 (Debezium 3.2.x) and 1.4.0 (Debezium 3.4.x).

### Notes for the reviewer

I verified this locally by building the native binary with GraalVM (`task package.native-executable`) and running `skemium generate`. Before this fix the binary crashed immediately, locally and in [CircleCI](https://app.circleci.com/pipelines/github/snyk/data-schema/2517/workflows/94df9e96-e70b-46f8-b0d3-235446257b03/jobs/15675).

I am not familiar enough with this to know if there is a way to test this going forward, other than smoke tests on the built binaries.

### Missed anything?

- [ ] Tests written (if applicable)
- [x] Documentation written (if applicable)
- [x] Commit history is tidy


### More information

- Jira ticket: https://snyksec.atlassian.net/browse/DGP-1695