### PR TITLE
ci: smoke test native binary against all commands [DP-3874]

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -138,7 +138,7 @@ jobs:
         run: |
           set -euo pipefail
           OUT_DIR=$(mktemp -d)
-          "$SKEMIUM_BIN" generate \
+          "$SKEMIUM_BIN" generate -vv \
             --hostname localhost --port 5432 \
             --database chinook \
             --username chinook-db-user --password chinook-db-pass \
@@ -152,20 +152,20 @@ jobs:
       - name: Smoke - compare (no changes => exit 0)
         run: |
           set -euo pipefail
-          "$SKEMIUM_BIN" compare \
+          "$SKEMIUM_BIN" compare -vv \
             --compatibility BACKWARD \
             src/test/resources/schema_change-no_changes/current \
             src/test/resources/schema_change-no_changes/next
       - name: Smoke - compare-files (compatible => exit 0)
         run: |
           set -euo pipefail
-          "$SKEMIUM_BIN" compare-files \
+          "$SKEMIUM_BIN" compare-files -vv \
             src/test/resources/compare-files/valid-schemas/person-v1.avsc \
             src/test/resources/compare-files/valid-schemas/person-v2-compatible.avsc
       - name: Smoke - compare-files (--include-schema)
         run: |
           set -euo pipefail
-          "$SKEMIUM_BIN" compare-files \
+          "$SKEMIUM_BIN" compare-files -vv \
             --include-schema src/test/resources/compare-files/multi-schema/issue-type.avsc \
             src/test/resources/compare-files/multi-schema/event-with-issue-ref.avsc \
             src/test/resources/compare-files/multi-schema/event-with-issue-ref.avsc

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -74,3 +74,101 @@ jobs:
           name: JUnit5 Tests
           reporter: java-junit
           path: target/surefire-reports/*.xml
+
+  native_smoke_test:
+    name: Native Binary Smoke Test
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v6
+      - name: Setup GraalVM
+        uses: graalvm/setup-graalvm@v1
+        with:
+          java-version: 21
+          distribution: graalvm
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          cache: maven
+          native-image-job-reports: true
+      - name: Build Native Binary
+        run: mvn -B package native:compile-no-fork -DskipTests
+      - name: Resolve Binary Path
+        run: |
+          set -euo pipefail
+          PROJ_NAME=$(mvn help:evaluate -Dexpression=project.name -q -DforceStdout)
+          PROJ_VER=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
+          OS_NAME=$(mvn help:evaluate -Dexpression=os.detected.name -q -DforceStdout)
+          OS_ARCH=$(mvn help:evaluate -Dexpression=os.detected.arch -q -DforceStdout)
+          BIN="$GITHUB_WORKSPACE/target/${PROJ_NAME}-${PROJ_VER}-${OS_NAME}-${OS_ARCH}"
+          test -x "$BIN" || { echo "Binary not found or not executable: $BIN"; ls -la "$GITHUB_WORKSPACE/target"; exit 1; }
+          echo "SKEMIUM_BIN=$BIN" >> "$GITHUB_ENV"
+      - name: Smoke - Binary boots and resolves build.version
+        run: |
+          set -euo pipefail
+          "$SKEMIUM_BIN" --version
+          "$SKEMIUM_BIN" --help
+      - name: Start PostgreSQL (Chinook fixture)
+        run: |
+          set -euo pipefail
+          docker run -d --name postgres \
+            --shm-size=128m \
+            -e POSTGRES_DB=chinook \
+            -e POSTGRES_USER=chinook-db-user \
+            -e POSTGRES_PASSWORD=chinook-db-pass \
+            -v "$GITHUB_WORKSPACE/src/test/resources/db_schema/chinook.initdb.sql:/docker-entrypoint-initdb.d/chinook.initdb.sql:ro" \
+            -p 5432:5432 \
+            postgres:17.2 \
+            -c wal_level=logical -c max_replication_slots=10 -c max_wal_senders=10
+          # Wait until Postgres is ready AND the init script has populated the chinook DB
+          for i in $(seq 1 60); do
+            if docker exec postgres pg_isready -U chinook-db-user -d chinook >/dev/null 2>&1; then
+              # Confirm the init script has run by checking for a known table
+              if docker exec -e PGPASSWORD=chinook-db-pass postgres \
+                  psql -U chinook-db-user -d chinook -tAc \
+                  "SELECT to_regclass('public.artist') IS NOT NULL" 2>/dev/null | grep -q '^t$'; then
+                echo "PostgreSQL ready with Chinook fixture loaded"
+                exit 0
+              fi
+            fi
+            sleep 2
+          done
+          echo "PostgreSQL did not become ready in time"
+          docker logs postgres
+          exit 1
+      - name: Smoke - generate
+        run: |
+          set -euo pipefail
+          OUT_DIR=$(mktemp -d)
+          "$SKEMIUM_BIN" generate \
+            --hostname localhost --port 5432 \
+            --database chinook \
+            --username chinook-db-user --password chinook-db-pass \
+            --table employee --table artist,album \
+            "$OUT_DIR"
+          test -f "$OUT_DIR/.skemium.meta.json"
+          test -f "$OUT_DIR/chinook.public.artist.key.avsc"
+          test -f "$OUT_DIR/chinook.public.artist.val.avsc"
+          test -f "$OUT_DIR/chinook.public.artist.env.avsc"
+          echo "GENERATE_OUT_DIR=$OUT_DIR" >> "$GITHUB_ENV"
+      - name: Smoke - compare (no changes => exit 0)
+        run: |
+          set -euo pipefail
+          "$SKEMIUM_BIN" compare \
+            --compatibility BACKWARD \
+            src/test/resources/schema_change-no_changes/current \
+            src/test/resources/schema_change-no_changes/next
+      - name: Smoke - compare-files (compatible => exit 0)
+        run: |
+          set -euo pipefail
+          "$SKEMIUM_BIN" compare-files \
+            src/test/resources/compare-files/valid-schemas/person-v1.avsc \
+            src/test/resources/compare-files/valid-schemas/person-v2-compatible.avsc
+      - name: Smoke - compare-files (--include-schema)
+        run: |
+          set -euo pipefail
+          "$SKEMIUM_BIN" compare-files \
+            --include-schema src/test/resources/compare-files/multi-schema/issue-type.avsc \
+            src/test/resources/compare-files/multi-schema/event-with-issue-ref.avsc \
+            src/test/resources/compare-files/multi-schema/event-with-issue-ref.avsc
+      - name: Stop PostgreSQL
+        if: always()
+        run: docker rm -f postgres || true

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,6 +6,10 @@ on:
   push:
     branches: [ main ]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 permissions:
   actions: read
   checks: write
@@ -17,6 +21,20 @@ env:
   SNYK_CLI_VERSION: v1.1300.1
 
 jobs:
+  changes:
+    name: Detect Changed Paths
+    runs-on: ubuntu-latest
+    outputs:
+      code: ${{ steps.filter.outputs.code }}
+    steps:
+      - uses: actions/checkout@v6
+      - id: filter
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            code:
+              - '!**/*.md'
+
   gitleaks:
     name: Gitleaks
     runs-on: ubuntu-latest
@@ -54,6 +72,8 @@ jobs:
   build_and_test:
     name: Build & Test
     runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     steps:
       - name: Checkout Code
         uses: actions/checkout@v6
@@ -78,6 +98,8 @@ jobs:
   native_smoke_test:
     name: Native Binary Smoke Test
     runs-on: ubuntu-24.04
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     steps:
       - name: Checkout Code
         uses: actions/checkout@v6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [unreleased]
+
+### Changed
+
+- CI now builds a GraalVM native binary on every PR and runs a smoke test against each subcommand (`generate`, `compare`, `compare-files`), so native-image regressions are caught before release rather than at tag time. See [#98](https://github.com/snyk/skemium/pull/98).
+- CI build and native-binary smoke jobs are now skipped on PRs that touch only Markdown files, while Gitleaks and Snyk continue to run. See [#98](https://github.com/snyk/skemium/pull/98).
+- CI now cancels in-flight runs on the same branch / PR when a new commit is pushed, so only the latest commit's checks consume runner minutes (pushes to `main` are exempt and always run to completion). See [#98](https://github.com/snyk/skemium/pull/98).
+
 ## [1.4.1] - 2026-05-14
 
 ### Fixed


### PR DESCRIPTION
JIRA: https://snyksec.atlassian.net/browse/DP-3874

## Summary

- Adds a `native_smoke_test` job to `ci.yaml` that builds a single GraalVM native binary on `ubuntu-24.04` and exercises every subcommand (`generate`, `compare`, `compare-files`) end-to-end, so native-image regressions (like the missing `build.version` resource fixed in #96) are caught on PRs instead of at release time.
- The job spins up a `postgres:17.2` container with the Chinook fixture (matching `WithPostgresContainer` config) for the `generate` smoke; `compare` / `compare-files` use checked-in fixtures and need no DB. Only happy paths are asserted (clean exit code) — incompatibility scenarios are intentionally out of scope to keep the smoke test reliant only on exit codes.

Closes #97

## CI optimizations (also in this PR)

While in here, two unrelated CI improvements were folded in:

- **Skip heavy jobs on docs-only changes** — a new `changes` job (`dorny/paths-filter`) gates `build_and_test` and `native_smoke_test` so they don't run when a PR only touches Markdown files. `gitleaks` and `snyk` continue to run on every change.
- **Cancel superseded in-flight runs** — workflow-level `concurrency` block cancels older runs on the same branch / PR when a new commit is pushed, freeing up runner minutes. Pushes to `main` are exempt and always run to completion.

> [!NOTE]
> If `Build & Test` or `Native Binary Smoke Test` are configured as **required** status checks on `main`, the docs-only skip will block merge of pure-`.md` PRs (the checks won't report). If that's the case, we can flip to a "report-success-immediately" pattern instead. Worth confirming branch protection settings before merge.

## Test plan

- [x] Native binary builds on `ubuntu-24.04` via `mvn -B package native:compile-no-fork -DskipTests`
- [x] `--version` and `--help` print and exit 0 (verifies `build.version` resource resolution — the #96 regression)
- [x] `generate` produces `.skemium.meta.json` and per-table `.avsc` files against a live Postgres
- [x] `compare` exits 0 against the no-changes fixture
- [x] `compare-files` exits 0 against compatible v1/v2 fixtures
- [x] `compare-files --include-schema` exits 0 against the multi-schema fixture
- [x] Confirm in-flight CI run on this PR is cancelled when a new commit is pushed
- [x] Confirm a docs-only follow-up commit skips `build_and_test` and `native_smoke_test`