### PR TITLE
chore(maintenance): dependencies version bump [TDPR-694]

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,9 +27,9 @@ jobs:
     outputs:
       code: ${{ steps.filter.outputs.code }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - id: filter
-        uses: dorny/paths-filter@v3
+        uses: dorny/paths-filter@v4
         with:
           filters: |
             code:
@@ -41,11 +41,11 @@ jobs:
     if: github.actor != 'dependabot[bot]'
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
       - name: Run Gitleaks
-        uses: gitleaks/gitleaks-action@v2
+        uses: gitleaks/gitleaks-action@v3
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE }}
@@ -55,7 +55,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.actor != 'dependabot[bot]'
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: Install Snyk
         uses: snyk/actions/setup@master
         with:
@@ -76,7 +76,7 @@ jobs:
     if: needs.changes.outputs.code == 'true'
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: Set up latest LTS JDK
         uses: actions/setup-java@v5
         with:
@@ -102,7 +102,7 @@ jobs:
     if: needs.changes.outputs.code == 'true'
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: Setup GraalVM
         uses: graalvm/setup-graalvm@v1
         with:

--- a/.github/workflows/release-binaries.yaml
+++ b/.github/workflows/release-binaries.yaml
@@ -31,7 +31,7 @@ jobs:
             os: macos
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: Setup GraalVM
         uses: graalvm/setup-graalvm@v1
         with:

--- a/.github/workflows/release-uberjar.yaml
+++ b/.github/workflows/release-uberjar.yaml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: Set up latest LTS JDK
         uses: actions/setup-java@v5
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,11 +14,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - **BREAKING:** Bumped Avro from `1.12.1` to `1.12.2`, which tightens schema parsing to match the Avro specification ([AVRO-4176](https://issues.apache.org/jira/browse/AVRO-4176)). A reference to a named type must now be written as a bare string (`"items": "Issue"`); the previously tolerated object form (`"items": { "type": "Issue", "name": "issue" }`) is rejected with `A schema "type" MUST be a primitive type or one of "enum", "fixed", "record", "error", "array" or "map"`. This mostly affects `compare-files --include-schema`, where types are resolved across multiple files. If your `.avsc` files use the object form, rewrite those references to the bare string form.
-- Bumped Java dependencies to their latest patch releases: `commons-codec` `1.22.0` → `1.22.1`, Jackson modules (`jackson-core`, `jackson-databind`, `jackson-datatype-jsr310`, `jackson-dataformat-avro`) `2.21.3` → `2.21.6`, `kafka-connect-avro-converter` `7.9.5` → `7.9.9`, `logback-classic` `1.5.32` → `1.5.38`, `lz4-java` `1.11.0` → `1.11.2`, and `postgresql` `42.7.11` → `42.7.13`.
-- Bumped GitHub Actions to their latest major versions: `actions/checkout` `v6` → `v7`, `dorny/paths-filter` `v3` → `v4`, and `gitleaks/gitleaks-action` `v2` → `v3`.
+- Bumped Java dependencies:
+  - `commons-codec` `1.22.0` → `1.22.1`
+  - `jackson-core`, `jackson-databind`, `jackson-datatype-jsr310`, `jackson-dataformat-avro` `2.21.3` → `2.21.6`
+  - `jgit` `7.6.0.202603022253-r` → `7.7.1.202607240634-r`
+  - `kafka-connect-avro-converter` `7.9.5` → `7.9.9`
+  - `logback-classic` `1.5.32` → `1.5.38`
+  - `lz4-java` `1.11.0` → `1.11.2`
+  - `postgresql` `42.7.11` → `42.7.13`
+- Bumped GitHub Actions:
+  - `actions/checkout` `v6` → `v7`
+  - `dorny/paths-filter` `v3` → `v4`
+  - `gitleaks/gitleaks-action` `v2` → `v3`
 - CI now builds a GraalVM native binary on every PR and runs a smoke test against each subcommand (`generate`, `compare`, `compare-files`), so native-image regressions are caught before release rather than at tag time. See [#98](https://github.com/snyk/skemium/pull/98).
 - CI build and native-binary smoke jobs are now skipped on PRs that touch only Markdown files, while Gitleaks and Snyk continue to run. See [#98](https://github.com/snyk/skemium/pull/98).
 - CI now cancels in-flight runs on the same branch / PR when a new commit is pushed, so only the latest commit's checks consume runner minutes (pushes to `main` are exempt and always run to completion). See [#98](https://github.com/snyk/skemium/pull/98).
+- CircleCI secrets-scanning and security-scan jobs now run with the `prodsec-orb-runtime` context (PRODSEC-10638). See [#116](https://github.com/snyk/skemium/pull/116).
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+> [!WARNING]
+> **Breaking change.** Some Avro schemas that Skemium accepted before are now rejected as invalid.
+> See the first entry under _Changed_ below, and bump with care.
+
 ### Changed
 
+- **BREAKING:** Bumped Avro from `1.12.1` to `1.12.2`, which tightens schema parsing to match the Avro specification ([AVRO-4176](https://issues.apache.org/jira/browse/AVRO-4176)). A reference to a named type must now be written as a bare string (`"items": "Issue"`); the previously tolerated object form (`"items": { "type": "Issue", "name": "issue" }`) is rejected with `A schema "type" MUST be a primitive type or one of "enum", "fixed", "record", "error", "array" or "map"`. This mostly affects `compare-files --include-schema`, where types are resolved across multiple files. If your `.avsc` files use the object form, rewrite those references to the bare string form.
+- Bumped Java dependencies to their latest patch releases: `commons-codec` `1.22.0` → `1.22.1`, Jackson modules (`jackson-core`, `jackson-databind`, `jackson-datatype-jsr310`, `jackson-dataformat-avro`) `2.21.3` → `2.21.6`, `kafka-connect-avro-converter` `7.9.5` → `7.9.9`, `logback-classic` `1.5.32` → `1.5.38`, `lz4-java` `1.11.0` → `1.11.2`, and `postgresql` `42.7.11` → `42.7.13`.
+- Bumped GitHub Actions to their latest major versions: `actions/checkout` `v6` → `v7`, `dorny/paths-filter` `v3` → `v4`, and `gitleaks/gitleaks-action` `v2` → `v3`.
 - CI now builds a GraalVM native binary on every PR and runs a smoke test against each subcommand (`generate`, `compare`, `compare-files`), so native-image regressions are caught before release rather than at tag time. See [#98](https://github.com/snyk/skemium/pull/98).
 - CI build and native-binary smoke jobs are now skipped on PRs that touch only Markdown files, while Gitleaks and Snyk continue to run. See [#98](https://github.com/snyk/skemium/pull/98).
 - CI now cancels in-flight runs on the same branch / PR when a new commit is pushed, so only the latest commit's checks consume runner minutes (pushes to `main` are exempt and always run to completion). See [#98](https://github.com/snyk/skemium/pull/98).

--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
 
     <!-- Main deps -->
     <ver.avro>1.12.1</ver.avro>
-    <ver.commons-codec>1.22.0</ver.commons-codec>
+    <ver.commons-codec>1.22.1</ver.commons-codec>
     <ver.commons-compress>1.28.0</ver.commons-compress>
     <ver.commons-lang3>3.20.0</ver.commons-lang3>
     <ver.debezium>3.4.3.Final</ver.debezium>
@@ -60,14 +60,14 @@
       doesn't use the patch version.
     -->
     <ver.jackson-annotations>2.21</ver.jackson-annotations>
-    <ver.jackson>2.21.3</ver.jackson>
+    <ver.jackson>2.21.6</ver.jackson>
     <ver.jgit>7.6.0.202603022253-r</ver.jgit>
-    <ver.kafka-connect-avro-converter>7.9.5</ver.kafka-connect-avro-converter>
+    <ver.kafka-connect-avro-converter>7.9.9</ver.kafka-connect-avro-converter>
     <ver.kafka>3.9.2</ver.kafka>
-    <ver.logback>1.5.32</ver.logback>
-    <ver.lz4-java>1.11.0</ver.lz4-java>
+    <ver.logback>1.5.38</ver.logback>
+    <ver.lz4-java>1.11.2</ver.lz4-java>
     <ver.picocli>4.7.7</ver.picocli>
-    <ver.postgresql>42.7.11</ver.postgresql>
+    <ver.postgresql>42.7.13</ver.postgresql>
     <ver.slf4j>2.0.18</ver.slf4j>
 
     <!-- Test deps -->

--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
     <!-- Main deps -->
-    <ver.avro>1.12.1</ver.avro>
+    <ver.avro>1.12.2</ver.avro>
     <ver.commons-codec>1.22.1</ver.commons-codec>
     <ver.commons-compress>1.28.0</ver.commons-compress>
     <ver.commons-lang3>3.20.0</ver.commons-lang3>

--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,7 @@
     -->
     <ver.jackson-annotations>2.21</ver.jackson-annotations>
     <ver.jackson>2.21.6</ver.jackson>
-    <ver.jgit>7.6.0.202603022253-r</ver.jgit>
+    <ver.jgit>7.7.1.202607240634-r</ver.jgit>
     <ver.kafka-connect-avro-converter>7.9.9</ver.kafka-connect-avro-converter>
     <ver.kafka>3.9.2</ver.kafka>
     <ver.logback>1.5.38</ver.logback>

--- a/src/test/java/io/snyk/skemium/CompareFilesResultTest.java
+++ b/src/test/java/io/snyk/skemium/CompareFilesResultTest.java
@@ -210,6 +210,26 @@ class CompareFilesResultTest {
     }
 
     @Test
+    void shouldFailWithIncludeSchemaWhenReferenceIsInObjectForm() {
+        // Avro 1.12.2 (AVRO-4176) rejects named type references written in object form,
+        // like `{"type": "Issue", "name": "issue"}`: only the bare string form is accepted.
+        final Path issueSchema = multiSchemaDir.resolve("issue-type.avsc");
+        final Path projectIssuesChangedSchema = multiSchemaDir.resolve("PRE-AVRO-4176-event-with-issue-ref.avsc");
+
+        final IOException exception = assertThrows(IOException.class, () -> {
+            CompareFilesResult.build(
+                    projectIssuesChangedSchema,
+                    projectIssuesChangedSchema,
+                    CompatibilityLevel.BACKWARD,
+                    List.of(issueSchema));
+        });
+
+        assertTrue(exception.getMessage().contains("Failed to parse current schema file"));
+        assertTrue(exception.getCause().getMessage().contains(
+                "A schema \"type\" MUST be a primitive type or one of"));
+    }
+
+    @Test
     void shouldWorkWithNullOrEmptyIncludeSchemas() throws IOException {
         final Path schema = validSchemasDir.resolve("person-v1.avsc");
 

--- a/src/test/resources/compare-files/multi-schema/PRE-AVRO-4176-event-with-issue-ref.avsc
+++ b/src/test/resources/compare-files/multi-schema/PRE-AVRO-4176-event-with-issue-ref.avsc
@@ -20,7 +20,7 @@
       "doc": "the issues data, unless it overflowed and was offloaded into the payloadUrl",
       "type": {
         "type": "array",
-        "items": "Issue"
+        "items": { "type": "Issue", "name": "issue" }
       },
       "default": []
     },


### PR DESCRIPTION
### What this does

Executes a patch version bump.

### Notes for the reviewer

But, it turns out, _semversion_ means something compeltely different for the Avro project. [Avro 1.12.2](https://github.com/apache/avro/releases/tag/release-1.12.2) released a bunch of breaking changes, and one affected us directly and it is not even called out as "breaking change". It is https://issues.apache.org/jira/browse/AVRO-4176. Technically this is a _fix_, but in truth it changes the behaviour of the API, on the basis that "but in Python it always worked this other way".

Anyway, I'll release Skemium with a _minor_ version bump, and plenty of indication of the breaking change in the CHANGELOG. Likely version `v1.5.0`.

### Missed anything?

- [x] Tests written (if applicable) [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [x] Documentation written (if applicable) [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### More information?

- Issue: [N/A](https://snyksec.atlassian.net/browse/TDPR-694)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Dependency bumps include a behavior-breaking Avro upgrade that rejects previously accepted schema syntax, plus CI workflow action version changes.
> 
> **Overview**
> Bumps Java dependencies and several GitHub Actions versions. The most significant change is upgrading Avro from `1.12.1` to `1.12.2`, which introduces a **breaking change**: named type references must now be bare strings (`"items": "Issue"`); the previously tolerated object form (`{"type": "Issue", "name": "issue"}`) is rejected. The existing test fixture was updated to the compliant form, a new pre-AVRO-4176 fixture was added, and a test was added to verify that the object form now fails parsing.
> 
> Also updates `actions/checkout` to `v7`, `dorny/paths-filter` to `v4`, and `gitleaks/gitleaks-action` to `v3` across CI and release workflows, and documents the breaking change and all version bumps in `CHANGELOG.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 27d7c9319de2d79109d0f4391d0bf699185ddccf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->